### PR TITLE
Add RunListener functionality

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
                  [clj-stacktrace              "0.2.8"]
                  [junit                       "4.12"]
                  [org.glassfish/javax.servlet "3.0"]
-                 [midje                       "1.8.2" :scope "test"]
+                 [midje                       "1.9.0-alpha6" :scope "test"]
                  [zilti/boot-midje            "0.2.2-SNAPSHOT" :scope "test"]
                  [radicalzephyr/bootlaces     "0.1.15-SNAPSHOT" :scope "test"]])
 

--- a/src/cljunit/core.clj
+++ b/src/cljunit/core.clj
@@ -117,6 +117,11 @@
     (when (seq test-classes)
       (let [^JUnitCore core (doto (JUnitCore.)
                               (.addListener (run-listener test-classes)))
+            _ (doseq [listener-name (:listeners filters)]
+                (let [klazz (Class/forName listener-name)
+                      constr (.getConstructor klazz (into-array Class []))
+                      ^RunListener obj (.newInstance constr (into-array Object []))]
+                  (.addListener core obj)))
             result (.run core
                          (into-array Class test-classes))]
         {:failures (.getFailureCount result)}))))


### PR DESCRIPTION
I wanted to be able to produce XML output from a JUnit run, so I needed a way to add a `RunListener`. This lets you supply a `:listeners` argument to `run-tests-in-classes` and it constructs instances of those classes and adds them as listeners.

It also bumps the Midje version so it will compile with Clojure 1.9 alphas (since Midje 1.8.2 has an illegal `ns` declaration in one of its dependencies).

With this PR merged, you can then update `boot-junit` to add a `-l / --listeners` task argument:
```
--- a/src/radicalzephyr/boot_junit.clj
+++ b/src/radicalzephyr/boot_junit.clj
@@ -40,6 +40,7 @@
 (core/deftask junit
   "Run the jUnit test runner."
   [c class-names  CLASSNAME #{str} "The set of Java class names to run tests from."
+   l listeners    CLASSNAME #{str} "The set of JUnit RunListener classes to add."
    p packages     PACKAGE   #{str} "The set of package names to run tests from."]
   (let [worker-pods (pod/pod-pool (update-in (core/get-env) [:dependencies] into pod-deps)
                                   :init init)]
@@ -50,6 +51,7 @@
         (if-let [result (pod/with-eval-in worker-pod
                           (run-tests-in-classes '~all-class-names
                                                 :classes ~class-names
+                                                :listeners ~listeners
                                                 :packages ~packages))]
           (when (> (:failures result) 0)
             (throw (ex-info "Some tests failed or errored" {})))
```
I couldn't find a released JAR containing an XML RunListener but this project has one https://github.com/barrypitman/JUnitXmlFormatter so I built and installed that locally and, with updated versions of `boot-junit` and `cljunit` built/installed, I was able to run:
```
BOOT_JVM_OPTIONS=-Dorg.schmant.task.junit4.target=junit_report.xml boot javac junit -l barrypitman.junitXmlFormatter.AntXmlRunListener
```
and get a nice `junit_report.xml` file!